### PR TITLE
Clarify ext4 FS requirements for EtherCAT

### DIFF
--- a/src/software_development/installation.rst
+++ b/src/software_development/installation.rst
@@ -246,9 +246,9 @@ EtherCAT is a high-speed fieldbus communication system used for real-time contro
 
     Before=network.service
 
-7. Reboot into the RT Kernel, if you're not in it already.
+6. Reboot into the RT Kernel, if you're not in it already.
 
-6. Enable the Ethercat service
+7. Enable the Ethercat service
 
   .. code-block:: bash
 


### PR DESCRIPTION
- **Ext4 File System:** Repeating the warning on the Installation page (for those skipping the detailed instructions in a sub-page)
- **EtherCAT configuration:** moving reboot into RT kernel *BEFORE* starting the EtherCAT master service