### PR TITLE
feat: deploy using GH action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,26 @@
+name: Deploy documentation to Pages
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  pages:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      pages: write
+      id-token: write
+    steps:
+    - name: checkout
+      uses: actions/checkout@v4
+      with:
+        token: ${{secrets.GH_PAT}}
+    - id: deployment
+      uses: sphinx-notes/pages@v3
+      with:
+        checkout: false
+        documentation_path: src
+        requirements_path: ./requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-esbonio==0.16.4
 furo==2023.9.10
 Sphinx==7.2.6
 sphinx-copybutton==0.5.2


### PR DESCRIPTION
With this PR, we'll start deploying to https://gmto.github.io/gmt_docs/ automatically every time a commit lands on `master`. There are no PR flows right now.

We can delete `gh-pages` branch as soon as we confirm everything is Ok.

This action does not build the PDF, we'll need to handle that separately. The old Jenkins job built it and uploaded to gh-pages branch. We can do it in this same action and save the artifacts as a release.